### PR TITLE
Expose `impl_no_dynamic_usage!()` macro for external use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All versions prior
 to 1.0.0 are beta releases.
 
-## Unreleased
+## [0.2.1] - 2022-09-24
 ### Added
 - `impl_no_dynamic_usage!()` helper macro to implement `DynamicUsage` for simple
   types that don't allocate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All versions prior
 to 1.0.0 are beta releases.
 
+## Unreleased
+### Added
+- `impl_no_dynamic_usage!()` helper macro to implement `DynamicUsage` for simple
+  types that don't allocate.
+
 ## [0.2.0] - 2021-09-14
 ### Added
 - `memuse::DynamicUsage` impls for the following types:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memuse"
 description = "Traits for measuring dynamic memory usage of types"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jack Grigg <thestr4d@gmail.com>"]
 documentation = "https://docs.rs/memuse/"
 homepage = "https://github.com/str4d/memuse"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,13 @@ impl_iterable_dynamic_usage!(VecDeque<T>, |c: &VecDeque<T>| {
     (c.capacity() + 1) * mem::size_of::<T>()
 });
 
+mod hash;
+
+//
+// External crate types (provided for helpfulness, since `DynamicUsage` can only be
+// implemented either here or in the external crate).
+//
+
 #[cfg(feature = "nonempty")]
 impl_iterable_dynamic_usage!(nonempty::NonEmpty<T>, |c: &nonempty::NonEmpty<T>| {
     // NonEmpty<T> stores its head element separately from its tail Vec<T>.
@@ -318,7 +325,6 @@ impl_iterable_dynamic_usage!(nonempty::NonEmpty<T>, |c: &nonempty::NonEmpty<T>| 
 // Larger definitions (placed at the end so they render more nicely in docs).
 //
 
-mod hash;
 mod tuple;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,52 @@ pub trait DynamicUsage {
 // Helper macros
 //
 
+/// Helper to implement [`DynamicUsage`] for simple types that don't allocate.
+///
+/// # Examples
+///
+/// ```
+/// // Must be imported so it is accessible to the macro.
+/// use memuse::DynamicUsage;
+///
+/// struct RegisterByte(u8);
+/// struct RegisterWord(u16);
+///
+/// memuse::impl_no_dynamic_usage!(RegisterByte, RegisterWord);
+/// ```
+///
+/// The above is equivalent to:
+/// ```
+/// use memuse::DynamicUsage;
+///
+/// struct RegisterByte(u8);
+/// struct RegisterWord(u16);
+///
+/// impl DynamicUsage for RegisterByte {
+///     #[inline(always)]
+///     fn dynamic_usage(&self) -> usize {
+///         0
+///     }
+///
+///     #[inline(always)]
+///     fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+///         (0, Some(0))
+///     }
+/// }
+///
+/// impl DynamicUsage for RegisterWord {
+///     #[inline(always)]
+///     fn dynamic_usage(&self) -> usize {
+///         0
+///     }
+///
+///     #[inline(always)]
+///     fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+///         (0, Some(0))
+///     }
+/// }
+/// ```
+#[macro_export]
 macro_rules! impl_no_dynamic_usage {
     ($($type:ty),+) => {
         $(


### PR DESCRIPTION
This should make it much easier for downstream developers to instrument their leaf types, to enable using the automatic impls from this crate.